### PR TITLE
fix compilation error on Android

### DIFF
--- a/src/llm.cpp
+++ b/src/llm.cpp
@@ -809,7 +809,7 @@ void TextVectorStore::save(const std::string& path) {
     std::vector<VARP> vars;
     vars.push_back(vectors_);
     for (auto text : texts_) {
-        auto text_var = _Const(text.data(), {text.size()}, NHWC, halide_type_of<int8_t>());
+        auto text_var = _Const(text.data(), {static_cast<int>(text.size())}, NHWC, halide_type_of<int8_t>());
         vars.push_back(text_var);
     }
     Variable::save(vars, path.c_str());


### PR DESCRIPTION
without static cast, compiler throws this error when cross-compiling for Android on both Mac and Linux:

>>>>>>>>>>
> Build command failed.
  Error while executing process /Users/windmaple/Library/Android/sdk/cmake/3.10.2.4988404/bin/ninja with arguments {-C /Users/windmaple/Desktop/project-src/mnn-llm/android/app/.cxx/cmake/debug/arm64-v8a llm_mnn}
  ninja: Entering directory `/Users/windmaple/Desktop/project-src/mnn-llm/android/app/.cxx/cmake/debug/arm64-v8a'
  [1/3] Building CXX object CMakeFiles/llm_mnn.dir/llm_mnn_jni.cpp.o
  [2/3] Building CXX object CMakeFiles/llm_mnn.dir/Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp.o
  FAILED: CMakeFiles/llm_mnn.dir/Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp.o 
  /Users/windmaple/Library/Android/sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --gcc-toolchain=/Users/windmaple/Library/Android/sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/darwin-x86_64 --sysroot=/Users/windmaple/Library/Android/sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/darwin-x86_64/sysroot  -DUSING_DISK_EMBED -Dllm_mnn_EXPORTS -I/Users/windmaple/Desktop/project-src/mnn-llm/android/app/src/main/jni/../../../../../include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -O0 -fno-limit-debug-info  -fPIC -MD -MT CMakeFiles/llm_mnn.dir/Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp.o -MF CMakeFiles/llm_mnn.dir/Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp.o.d -o CMakeFiles/llm_mnn.dir/Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp.o -c /Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp
  /Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp:812:46: error: non-constant-expression cannot be narrowed from type 'std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >::size_type' (aka 'unsigned long') to 'int' in initializer list [-Wc++11-narrowing]
          auto text_var = _Const(text.data(), {text.size()}, NHWC, halide_type_of<int8_t>());
                                               ^~~~~~~~~~~
  /Users/windmaple/Desktop/project-src/mnn-llm/src/llm.cpp:812:46: note: insert an explicit cast to silence this issue
          auto text_var = _Const(text.data(), {text.size()}, NHWC, halide_type_of<int8_t>());
                                               ^~~~~~~~~~~
                                               static_cast<int>( )
  1 error generated.
  ninja: build stopped: subcommand failed.