### PR TITLE
解决amr windows下一些文件编译失败的错误

### DIFF
--- a/demo/embedding_demo.cpp
+++ b/demo/embedding_demo.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 //  embedding_demo.cpp
 //
 //  Created by MNN on 2024/01/10.

--- a/demo/store_demo.cpp
+++ b/demo/store_demo.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 //  store_demo.cpp
 //
 //  Created by MNN on 2024/01/10.

--- a/src/llm.cpp
+++ b/src/llm.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 //  llm.cpp
 //
 //  Created by MNN on 2023/08/25.

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 //  tokenizer.cpp
 //
 //  Created by MNN on 2023/09/25.


### PR DESCRIPTION
\embedding_demo.cpp(34,39): error C2001: 常量中有换行符 [C:\fastllm\mnn\mnn-llm\mnn- llm\build\embedding_demo.vcxproj]
embedding_demo.cpp(35,5): error C2144: 语法错误:“auto”的前面应有“)” [C:\fastllm\mnn\m nn-llm\mnn-llm\build\embedding_demo.vcxproj]embedding_demo.cpp(35,39): error C2001: 常量中有换行符 [C:\fastllm\mnn\mnn-llm\mnn- llm\build\embedding_demo.vcxproj]